### PR TITLE
BuildRequire vulkan-headers not vulkan-devel to ease llvm updates

### DIFF
--- a/fedora/mesa-git/mesa.spec.tpl
+++ b/fedora/mesa-git/mesa.spec.tpl
@@ -163,7 +163,7 @@ BuildRequires:  pkgconfig(valgrind)
 BuildRequires:  python3-devel
 BuildRequires:  python3-mako
 %if 0%{?with_hardware}
-BuildRequires:  vulkan-devel
+BuildRequires:  vulkan-headers
 %endif
 ## vulkan hud requires
 %if 0%{?with_vulkan_overlay}


### PR DESCRIPTION
I did changed BuildRequires as in original mesa.spec file https://src.fedoraproject.org/rpms/mesa/blob/master/f/mesa.spec#_142 without this change mesa local build with non system LLVM looks like hell.