### PR TITLE
Decreasing Clang build time on multi-threaded CPU

### DIFF
--- a/fedora/llvm-git/clang/clang.spec.tpl
+++ b/fedora/llvm-git/clang/clang.spec.tpl
@@ -279,10 +279,10 @@ cd _build
 	-DCLANG_BUILD_EXAMPLES:BOOL=OFF \
 	-DCLANG_REPOSITORY_STRING="%{?fedora:Fedora}%{?rhel:Red Hat} %{version}-%{release}"
 
-ninja -j 1
+%ninja_build
 
 %install
-DESTDIR=%{buildroot} ninja install -C _build
+%ninja_install -C _build
 
 %if 0%{?compat_build}
 


### PR DESCRIPTION
On my CPU Ryzen 9 x3950 build time decreased from 2 hours to 20 minutes. For such build is enough RAM 32Gb + 64Gb swap.