### PR TITLE
Enable Intel HASVK Vulkan driver

### DIFF
--- a/fedora/mesa-git/mesa.spec
+++ b/fedora/mesa-git/mesa.spec
@@ -35,7 +35,7 @@
 %global with_vmware 1
 %global with_xa     1
 %global with_zink   1
-%global vulkan_drivers intel,amd
+%global vulkan_drivers intel,intel_hasvk,amd
 %else
 %ifnarch s390x
 %global vulkan_drivers amd
@@ -638,6 +638,8 @@ popd
 %ifarch %{ix86} x86_64
 %{_libdir}/libvulkan_intel.so
 %{_datadir}/vulkan/icd.d/intel_icd.*.json
+%{_libdir}/libvulkan_intel_hasvk.so
+%{_datadir}/vulkan/icd.d/intel_hasvk_icd.*.json
 %endif
 %{_libdir}/libvulkan_radeon.so
 %{_datadir}/vulkan/icd.d/radeon_icd.*.json


### PR DESCRIPTION
The Intel ANV Vulkan driver no longer supports Gen7/8 integrated graphics, instead, the Vulkan support for these GPUs has been moved into a new "HASVK" driver.

[These changes were tested successfully on Fedora 37 (on my Intel Core i5-4200M), and built successfully for Fedora 35 and 36 as well.](https://copr.fedorainfracloud.org/coprs/retrixe/mesa-git/)