### PR TITLE
Activer vulkan "nouveau-experimental" pour nvk

### DIFF
--- a/fedora/mesa-git/mesa.spec
+++ b/fedora/mesa-git/mesa.spec
@@ -34,7 +34,7 @@
 %global with_iris   1
 %global with_vmware 1
 %global with_xa     1
-%global vulkan_drivers intel,intel_hasvk,amd
+%global vulkan_drivers intel,intel_hasvk,amd,nouveau-experimental
 %else
 %ifnarch s390x
 %global vulkan_drivers amd


### PR DESCRIPTION
Hello, I sincerely apologize for the trouble, could you please add "nouveau-experimental" to "VULKAN_DRIVERS" for x86_64 as in https://gitlab.freedesktop.org/mesa/mesa/-/commit/edab54dd685f2829ecc5d7e5e34910e4a9f2fd62 to test nvk. If I'm not mistaken, you don't need to edit anything else. Thank you in advance.